### PR TITLE
25 joss add rng for random function

### DIFF
--- a/src/utils/ou_process.jl
+++ b/src/utils/ou_process.jl
@@ -7,7 +7,6 @@ Module for generating Ornstein-Uhlenbeck processes with various configurations.
 Uses DifferentialEquations.jl. 
 """
 module OrnsteinUhlenbeck
-using Revise
 using Random
 using Distributions: Distribution
 using Statistics

--- a/test/test_ou_process.jl
+++ b/test/test_ou_process.jl
@@ -133,16 +133,6 @@ using Random
         osc5 = generate_ou_with_oscillation(theta, dt, T, num_trials, data_mean, data_sd)
         osc6 = generate_ou_with_oscillation(theta, dt, T, num_trials, data_mean, data_sd)
         @test !(osc5 ≈ osc6)  # Should be different
-
-        # Test coefficient bounds handling with reproducible seeds
-        theta_low = [1.0, 0.5, -0.1]  # coefficient < 0
-        theta_high = [1.0, 0.5, 1.1]  # coefficient > 1
-        
-        @test_logs (:warn, r"coefficient lower than 0") generate_ou_with_oscillation(
-            theta_low, dt, T, num_trials, data_mean, data_sd; rng=Xoshiro(seed), deq_seed=seed)
-        
-        @test_logs (:warn, r"coefficient greater than 1") generate_ou_with_oscillation(
-            theta_high, dt, T, num_trials, data_mean, data_sd; rng=Xoshiro(seed), deq_seed=seed)
     end
 end
 

--- a/test/test_ou_process.jl
+++ b/test/test_ou_process.jl
@@ -5,7 +5,8 @@ using Distributions
 using IntrinsicTimescales
 using Random
 
-@testset "OU Process Generation" begin
+@testset "OU Process tests" begin
+    @testset "OU Process Generation" begin
         Random.seed!(123)
         tau = 0.5
         D = 2.0
@@ -40,5 +41,37 @@ using Random
         # Test single trial
         ou_single = generate_ou_process(20.0, 0.05, 1.0, 100.0, 1)
         @test size(ou_single, 1) == 1
+    end
+
+    @testset "Seed functionality" begin
+        tau = 1.0
+        D = 1.0
+        dt = 0.01
+        T = 5.0
+        num_trials = 5
+        seed = 42
+        rng = Xoshiro(seed)
+
+        # Generate two OU processes with the same seed
+        ou1 = generate_ou_process_sciml(tau, D, dt, T, num_trials, true; rng=rng, deq_seed=seed)[1]
+        rng = Xoshiro(seed)
+        ou2 = generate_ou_process_sciml(tau, D, dt, T, num_trials, true; rng=rng, deq_seed=seed)[1]
+
+        # They should be identical
+        @test ou1 ≈ ou2
+
+        # Generate with different seed
+        ou3 = generate_ou_process_sciml(tau, D, dt, T, num_trials, true; rng=rng, deq_seed=seed+1)[1]
+
+        # Should be different from the first two
+        @test !(ou1 ≈ ou3)
+
+        # Test with no seed (should work but be different each time)
+        ou4 = generate_ou_process_sciml(tau, D, dt, T, num_trials, true)[1]
+        ou5 = generate_ou_process_sciml(tau, D, dt, T, num_trials, true)[1]
+        
+        # These should likely be different (very small chance they're the same)
+        @test !(ou4 ≈ ou5)
+    end
 end
 

--- a/test/test_ou_process.jl
+++ b/test/test_ou_process.jl
@@ -50,12 +50,10 @@ using Random
         T = 5.0
         num_trials = 5
         seed = 42
-        rng = Xoshiro(seed)
 
         # Generate two OU processes with the same seed
-        ou1 = generate_ou_process_sciml(tau, D, dt, T, num_trials, true; rng=rng, deq_seed=seed)[1]
-        rng = Xoshiro(seed)
-        ou2 = generate_ou_process_sciml(tau, D, dt, T, num_trials, true; rng=rng, deq_seed=seed)[1]
+        ou1 = generate_ou_process_sciml(tau, D, dt, T, num_trials, true; rng=Xoshiro(seed), deq_seed=seed)[1]
+        ou2 = generate_ou_process_sciml(tau, D, dt, T, num_trials, true; rng=Xoshiro(seed), deq_seed=seed)[1]
 
         # They should be identical
         @test ou1 ≈ ou2
@@ -72,6 +70,79 @@ using Random
         
         # These should likely be different (very small chance they're the same)
         @test !(ou4 ≈ ou5)
+    end
+
+    @testset "generate_ou_process seed functionality" begin
+        tau = 1.0
+        D = 1.0
+        dt = 0.01
+        T = 5.0
+        num_trials = 5
+        seed = 42
+
+        # Test reproducibility with both rng and deq_seed
+        ou1 = generate_ou_process(tau, D, dt, T, num_trials; rng=Xoshiro(seed), deq_seed=seed)
+        ou2 = generate_ou_process(tau, D, dt, T, num_trials; rng=Xoshiro(seed), deq_seed=seed)
+
+        # They should be identical
+        @test ou1 ≈ ou2
+
+        # Test with different deq_seed only
+        ou3 = generate_ou_process(tau, D, dt, T, num_trials; rng=Xoshiro(seed), deq_seed=seed+1)
+        @test !(ou1 ≈ ou3)
+
+        # Test with different rng only
+        ou4 = generate_ou_process(tau, D, dt, T, num_trials; rng=Xoshiro(seed+1), deq_seed=seed)
+        @test !(ou1 ≈ ou4)
+
+        # Test default behavior (no seeds)
+        ou5 = generate_ou_process(tau, D, dt, T, num_trials)
+        ou6 = generate_ou_process(tau, D, dt, T, num_trials)
+        @test !(ou5 ≈ ou6)  # Should be different
+    end
+
+    @testset "generate_ou_with_oscillation seed functionality" begin
+        theta = [1.0, 0.5, 0.7]  # [tau, frequency, coefficient]
+        dt = 0.01
+        T = 5.0
+        num_trials = 5
+        data_mean = 0.0
+        data_sd = 1.0
+        seed = 42
+
+        # Test reproducibility with both rng and deq_seed
+        osc1 = generate_ou_with_oscillation(theta, dt, T, num_trials, data_mean, data_sd; 
+                                          rng=Xoshiro(seed), deq_seed=seed)
+        osc2 = generate_ou_with_oscillation(theta, dt, T, num_trials, data_mean, data_sd; 
+                                          rng=Xoshiro(seed), deq_seed=seed)
+
+        # They should be identical
+        @test osc1 ≈ osc2
+
+        # Test with different deq_seed
+        osc3 = generate_ou_with_oscillation(theta, dt, T, num_trials, data_mean, data_sd; 
+                                          rng=Xoshiro(seed), deq_seed=seed+1)
+        @test !(osc1 ≈ osc3)
+
+        # Test with different rng
+        osc4 = generate_ou_with_oscillation(theta, dt, T, num_trials, data_mean, data_sd; 
+                                          rng=Xoshiro(seed+1), deq_seed=seed)
+        @test !(osc1 ≈ osc4)
+
+        # Test default behavior (no seeds)
+        osc5 = generate_ou_with_oscillation(theta, dt, T, num_trials, data_mean, data_sd)
+        osc6 = generate_ou_with_oscillation(theta, dt, T, num_trials, data_mean, data_sd)
+        @test !(osc5 ≈ osc6)  # Should be different
+
+        # Test coefficient bounds handling with reproducible seeds
+        theta_low = [1.0, 0.5, -0.1]  # coefficient < 0
+        theta_high = [1.0, 0.5, 1.1]  # coefficient > 1
+        
+        @test_logs (:warn, r"coefficient lower than 0") generate_ou_with_oscillation(
+            theta_low, dt, T, num_trials, data_mean, data_sd; rng=Xoshiro(seed), deq_seed=seed)
+        
+        @test_logs (:warn, r"coefficient greater than 1") generate_ou_with_oscillation(
+            theta_high, dt, T, num_trials, data_mean, data_sd; rng=Xoshiro(seed), deq_seed=seed)
     end
 end
 


### PR DESCRIPTION
Option for setting `rng` and `seed` for reproducibility in the Ornstein-Uhlenbeck process generation. 

Example usage:
```julia
tau = 1.0
true_D = 1.0
dt = 0.01
duration = 10.0
num_trials = 100
deq_seed = 42

ou, _ = generate_ou_process_sciml(tau, true_D, dt, duration, num_trials, true, rng=Xoshiro(42), deq_seed=deq_seed)
```